### PR TITLE
Use literal tabs in sed(1) regular expressions

### DIFF
--- a/m_abook.sh.in
+++ b/m_abook.sh.in
@@ -31,7 +31,7 @@ m_abook_query()
 	    if [ -f "$book" ]
 	    then
 		$ABOOK --datafile $book --mutt-query "$@" \
-		| sed -e '1d;s/\([^\t]*\t[^\t]*\).*/\1\tabook/'
+		| sed -e '1d;s/\([^	]*	[^	]*\).*/\1	abook/'
 	    fi
 	done
     fi

--- a/m_goobook.sh.in
+++ b/m_goobook.sh.in
@@ -28,6 +28,6 @@ m_goobook_query()
     if [ -x "$GOOBOOK" ]		# check whether goobook in installed
     then
         $GOOBOOK query "$@" \
-            | sed -e '1d;s/\([^\t]*\t[^\t]*\).*/\1\tgoobook/'
+            | sed -e '1d;s/\([^	]*	[^	]*\).*/\1	goobook/'
     fi
 }


### PR DESCRIPTION
Use literal tab characters in order to make `m_abook` and `m_goobook` modules work without requiring `GNU` `sed(1)`.