### PR TITLE
add scope option to mutt ldap query

### DIFF
--- a/lbdb_ldap.rc
+++ b/lbdb_ldap.rc
@@ -10,9 +10,9 @@
 #                   'LDAP_RESULT_COMMENT',
 #                   'IGNORANT' (optional),
 #                   'LDAP_BIND_DN' (optional),
-#                   'LDAP_BIND_PASSWORD (optional),
-#                   'LDAP_TLS (optional),
-#                   'LDAP_SASL_MECH (optional)],
+#                   'LDAP_BIND_PASSWORD' (optional),
+#                   'LDAP_TLS' (optional),
+#                   'LDAP_SASL_MECH' (optional),
 # (IGNORANT is an optional argument. If you set it to 1, mutt_ldap_query
 # uses wildcards *foo* for searching).
 # (LDAP_BIND_DN and LDAP_BIND_PASSWORD are optional arguments. Leave them

--- a/lbdb_ldap.rc
+++ b/lbdb_ldap.rc
@@ -13,12 +13,14 @@
 #                   'LDAP_BIND_PASSWORD' (optional),
 #                   'LDAP_TLS' (optional),
 #                   'LDAP_SASL_MECH' (optional),
+#                   'SCOPE' (optional)],
 # (IGNORANT is an optional argument. If you set it to 1, mutt_ldap_query
 # uses wildcards *foo* for searching).
 # (LDAP_BIND_DN and LDAP_BIND_PASSWORD are optional arguments. Leave them
 # out or empty to use and anonymous bind)
 # (LDAP_TLS is optional, set it to 0 to disable)
 # (LDAP_SASL_MECH is optional, set it to '' to disable)
+# (SCOPE is optional, set it to undef to use default scope)
 # A practical illustrating example being:
 #  debian	=> ['db.debian.org', 'ou=users,dc=debian,dc=org',
 #                   'uid cn sn ircnick', 'uid cn sn ircnick',
@@ -83,4 +85,5 @@ $ldap_bind_password = '';
 # Don't use TLS:
 $ldap_tls = 0;
 $ldap_sasl_mech = '';
+$ldap_scope = undef;
 1;

--- a/mutt_ldap_query.pl.in
+++ b/mutt_ldap_query.pl.in
@@ -59,6 +59,8 @@ our $ldap_bind_password = '';
 our $ldap_tls = 0;
 # LDAP SASL mechanism
 our $ldap_sasl_mech = '';
+# option to restrict the scope of the LDAP search
+our $scope = undef;
 
 our %ldap_server_db = (
   'four11'		=> ['ldap.four11.com', 'c=US', 'givenname sn cn mail', 'givenname cn sn mail o', '${mail}', '${givenname} ${sn}', '${o}' ],
@@ -120,6 +122,7 @@ GetOptions (
   'bind_password|bp:s'          => \$ldap_bind_password,
   'tls:s'                       => \$ldap_tls,
   'sasl_mech|sm:s'              => \$ldap_sasl_mech,
+  'scope=s'                     => \$scope,
   'debug'			=> sub { $DEBUG = 1 },
   'help|?|h'			=> \$help,
   'man|m'			=> \$man,
@@ -212,7 +215,7 @@ foreach my $askfor ( @ARGV ) {
   } else {
     $ldap->bind;
   }
-  my $mesg = $ldap->search( base => $search_base, filter => $query ) or die $@;
+  my $mesg = $ldap->search( base => $search_base, filter => $query, $scope ? (scope => $scope) : () ) or die $@;
   if ($mesg->code && ($mesg->code ne '4')) {
     die "Search failed. LDAP server returned an error : ", $mesg->code, ", description: ", $mesg->error;
   }

--- a/mutt_ldap_query.pl.in
+++ b/mutt_ldap_query.pl.in
@@ -60,7 +60,7 @@ our $ldap_tls = 0;
 # LDAP SASL mechanism
 our $ldap_sasl_mech = '';
 # option to restrict the scope of the LDAP search
-our $scope = undef;
+our $ldap_scope = undef;
 
 our %ldap_server_db = (
   'four11'		=> ['ldap.four11.com', 'c=US', 'givenname sn cn mail', 'givenname cn sn mail o', '${mail}', '${givenname} ${sn}', '${o}' ],
@@ -122,7 +122,7 @@ GetOptions (
   'bind_password|bp:s'          => \$ldap_bind_password,
   'tls:s'                       => \$ldap_tls,
   'sasl_mech|sm:s'              => \$ldap_sasl_mech,
-  'scope=s'                     => \$scope,
+  'scope=s'                     => \$ldap_scope,
   'debug'			=> sub { $DEBUG = 1 },
   'help|?|h'			=> \$help,
   'man|m'			=> \$man,
@@ -215,7 +215,7 @@ foreach my $askfor ( @ARGV ) {
   } else {
     $ldap->bind;
   }
-  my $mesg = $ldap->search( base => $search_base, filter => $query, $scope ? (scope => $scope) : () ) or die $@;
+  my $mesg = $ldap->search( base => $search_base, filter => $query, $ldap_scope ? (scope => $ldap_scope) : () ) or die $@;
   if ($mesg->code && ($mesg->code ne '4')) {
     die "Search failed. LDAP server returned an error : ", $mesg->code, ", description: ", $mesg->error;
   }
@@ -344,6 +344,13 @@ enable or disable transport layer security (TLS).
 =item B<--sasl_mech=mechanism> or B<-sm mechanism>
 
 the SASL mechanism, for example GSSAPI (empty string to turn off).
+
+=item B<--scope=ldap_scope>
+
+The default search applies to the whole tree. Specifying the optional scope
+parameter allows the search to be limited in various ways. Some valid values
+include: 'base', 'one', 'sub', 'subtree', 'children'. See the Net::LDAP CPAN
+documentation for more information.
 
 =item B<--nickname=ldap_server_nickname> or B<-n ldap_server_nickname>
 

--- a/mutt_ldap_query.pl.in
+++ b/mutt_ldap_query.pl.in
@@ -177,6 +177,9 @@ if ($ldap_server_nickname) {
   if (defined($option_array->[11])) {
      $ldap_sasl_mech = $option_array->[11];
   }
+  if (defined($option_array->[12])) {
+     $ldap_scope = $option_array->[12];
+  }
 }
 
 print "DEBUG: ldap_server='$ldap_server' search_base='$search_base' search_fields='$ldap_search_fields'\


### PR DESCRIPTION
This adds an option to provide a scope parameter to the Net::LDAP search method.

I needed this to filter out entries from my LDAP queries. Default behaviour is unchanged if this parameter is not specified.