### PR TITLE
m_mu: Also select addresses without a name & remove overfluous quotes

### DIFF
--- a/m_mu.sh.in
+++ b/m_mu.sh.in
@@ -36,6 +36,6 @@ m_mu_query()
     if [ -x "$MU" ]                # check whether mu is installed
     then
 	$MU cfind --format=csv $MU_OPTIONS "$@" \
-        | sed -e 's/^,\([^,]*\)/\1,\1/' -e 's/\(.*\),\([^,]*\)/\2	\1	mu cfind/'
+        | sed -e 's/^,\([^,]*\)/\1,\1/' -e 's/\(.*\),\([^,]*\)/\2	\1	mu cfind/' | tr -d '"'
     fi
 }

--- a/m_mu.sh.in
+++ b/m_mu.sh.in
@@ -36,6 +36,6 @@ m_mu_query()
     if [ -x "$MU" ]                # check whether mu is installed
     then
 	$MU cfind --format=csv $MU_OPTIONS "$@" \
-        | sed -e '/^,/d' -e 's/\(.*\),\([^,]*\)/\2	\1	mu cfind/'
+        | sed -e 's/^,\([^,]*\)/\1,\1/' -e 's/\(.*\),\([^,]*\)/\2	\1	mu cfind/'
     fi
 }


### PR DESCRIPTION
This change would allow to search for a sole mail address from `m_mu` even when the mail address doesn't have a `Name` attribute. In that case the Mail address is set as the Name.